### PR TITLE
M1 morefeatures

### DIFF
--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -121,6 +121,14 @@ struct SegmentInfo {
 struct AllocFreeEvent {
   intptr_t ptr; // start location in memory
   int size; // size in bytes, negative size for free
+  bool raw_alloc = false; // if it is a raw allocation
+  bool served_by_cached = false; // if served by a cached block
+  bool served_by_new_block =
+      false; // if served after allocating a new block of sufficient size
+  bool served_by_new_block_retry =
+      false; // if served with a new block after freeing one cached block of
+             // sufficient size
+  bool defrag = false; // if allocated after defragmentation
 };
 
 C10_CUDA_API void* raw_alloc(size_t nbytes);

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -655,7 +655,22 @@ static void bindGetAllocFreeEvents(PyObject* module) {
       .def_readwrite(
           "ptr", &c10::cuda::CUDACachingAllocator::AllocFreeEvent::ptr)
       .def_readwrite(
-          "size", &c10::cuda::CUDACachingAllocator::AllocFreeEvent::size);
+          "size", &c10::cuda::CUDACachingAllocator::AllocFreeEvent::size)
+      .def_readwrite(
+          "raw_alloc",
+          &c10::cuda::CUDACachingAllocator::AllocFreeEvent::raw_alloc)
+      .def_readwrite(
+          "served_by_cached",
+          &c10::cuda::CUDACachingAllocator::AllocFreeEvent::served_by_cached)
+      .def_readwrite(
+          "served_by_new_block",
+          &c10::cuda::CUDACachingAllocator::AllocFreeEvent::served_by_new_block)
+      .def_readwrite(
+          "served_by_new_block_retry",
+          &c10::cuda::CUDACachingAllocator::AllocFreeEvent::
+              served_by_new_block_retry)
+      .def_readwrite(
+          "defrag", &c10::cuda::CUDACachingAllocator::AllocFreeEvent::defrag);
   m.def(
       "_get_alloc_free_events",
       &c10::cuda::CUDACachingAllocator::getAllocFreeEvents,


### PR DESCRIPTION
Follow up on PR: https://github.com/pytorch/pytorch/pull/81753

Now each free/allocate event includes the following bool flags:

raw_alloc: indicates if the allocation is raw
served_by_cached: indicates if the allocation is served by a cached block
served_by_new_block: indicates if the allocation is served by a new block
served_by_new_block_retry: indicates if the allocation is served by a new block after freeing one cached block
defrag: indicates if the allocation is served by a new block after defragmentation (freeing all cached blocks)